### PR TITLE
feat: add agent file logging and unify logger configuration

### DIFF
--- a/logger/__init__.py
+++ b/logger/__init__.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 """Logger module for GeoAgent plugin."""
 
-from .logger import UILogHandler, get_logger, UILogSignal
-from .processing_logger import (
-	get_processing_logger,
-	set_processing_ui_log_handler,
-)
+from .logger import get_logger, configure_logger, attach_ui_handler
+from .processing_logger import get_processing_logger
 
 __all__ = [
-	"UILogHandler",
-	"get_logger",
-	"UILogSignal",
-	"get_processing_logger",
-	"set_processing_ui_log_handler",
+    "get_logger",
+    "configure_logger",
+    "attach_ui_handler",
+    "get_processing_logger",
 ]

--- a/logger/processing_logger.py
+++ b/logger/processing_logger.py
@@ -1,43 +1,18 @@
 # -*- coding: utf-8 -*-
 """Processing-specific logger helpers for GeoAgent.
 
-This centralizes the processing logger and its UI handler wiring so that
-logging concerns stay within the logger package.
+Provides a shared processing logger that inherits configuration
+from the main GeoAgent logger.
 """
 
 import logging
-from typing import Optional
-
-from ..config.settings import SHOW_DEBUG_LOGS
-from .logger import get_logger, UILogHandler
+from .logger import get_logger
 
 
-# Create processing logger (no UI handler attached here; UI is wired at runtime)
-_processing_logger = get_logger(
-    "GeoAgent.Processing",
-    text_browser=None,
-    show_debug=SHOW_DEBUG_LOGS,
-    level=logging.DEBUG if SHOW_DEBUG_LOGS else logging.INFO,
-)
-# Let messages propagate to root; root will carry the UI handler
-_processing_logger.propagate = True
+# Processing logger inherits handlers and level from core logger
+_processing_logger = get_logger("processing")
 
 
 def get_processing_logger() -> logging.Logger:
     """Return the shared processing logger instance."""
     return _processing_logger
-
-
-def set_processing_ui_log_handler(ui_log_handler: Optional[UILogHandler]) -> None:
-    """Ensure processing logs flow to the shared UI handler via root.
-
-    We avoid attaching the UI handler directly to prevent duplicate delivery; the
-    handler is expected to be registered on the root logger upstream.
-    """
-    global _processing_logger
-    if ui_log_handler is None:
-        return
-
-    # Remove any direct attachment of this UI handler to avoid duplicates
-    _processing_logger.handlers = [h for h in _processing_logger.handlers if h is not ui_log_handler]
-    _processing_logger.propagate = True


### PR DESCRIPTION
### Adding persistent agent log file for GeoAgent

This PR adds file-based logging for GeoAgent under the QGIS profile directory.

- Introduces a unified agent logger with a persistent log file
- Processing logs inherit the same logger
- No UI or behavior changes
- No breaking changes

Log file location:
<QGIS profile>/GeoAgent/geo_agent.log

<img width="700" alt="geo_agent.log showing agent initialization" src="https://github.com/user-attachments/assets/9b1daf5e-3fd6-417d-b0ff-6e9336c1440d" />

Fixes #3 